### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+
+## [1.5.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [1.5.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [1.4.0] - 2019-04-16
 
 ### Changed
@@ -16,6 +27,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Set max version to 10
 
-[Unreleased]: https://github.com/owncloud/external/compare/v1.4.0...master
+[Unreleased]: https://github.com/owncloud/external/compare/v1.5.1..master
+[1.5.1]: https://github.com/owncloud/external/compare/v1.5.0..v1.5.1
+[1.5.0]: https://github.com/owncloud/external/compare/v1.4.0..v1.5.0
 [1.4.0]: https://github.com/owncloud/external/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/owncloud/external/compare/v1.3.0...v1.3.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,5 +20,5 @@
 	<dependencies>
 		<owncloud min-version="10.15" max-version="11" />
 	</dependencies>
-	<version>1.5.0</version>
+	<version>1.5.1</version>
 </info>


### PR DESCRIPTION
Patch-level version bump (1.5.0 -> 1.5.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.