### PR TITLE
refactor(routing): rewire the setsites ajax route to an extension-free url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Rewire the setsites ajax route to an extension-free url so it is reachable at its own declared url - [#32](https://github.com/owncloud/external/pull/32)
 
 ## [1.5.1] - 2026-07-22
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -8,5 +8,5 @@
 /** @var $this \OCP\Route\IRouter */
 $this->create('external_index', '/{id}')
 	->actionInclude('external/index.php');
-$this->create('external_ajax_setsites', 'ajax/setsites.php')
+$this->create('external_ajax_setsites', 'ajax/setsites')
 	->actionInclude('external/ajax/setsites.php');

--- a/js/admin.js
+++ b/js/admin.js
@@ -24,7 +24,7 @@ $(document).ready(function(){
 	function saveSites() {
 		var post = $('#external').serialize();
 		OC.msg.startSaving('#external .msg');
-		$.post( OC.filePath('external','ajax','setsites.php') , post, function(data) {
+		$.post( OC.generateUrl('/apps/external/ajax/setsites') , post, function(data) {
 			OC.msg.finishedSaving('#external .msg', data);
 		});
 	}


### PR DESCRIPTION
## Description

Hardening, in the same class as owncloud/core#41740 and rewired the same way as
owncloud/core#41742. **No user-visible behaviour change** — see *Impact* below.

`appinfo/routes.php` declared

```php
$this->create('external_ajax_setsites', 'ajax/setsites.php')
    ->actionInclude('external/ajax/setsites.php');
```

The router prefixes app route urls with `/apps/<appid>`, so the declared url
becomes `/apps/external/ajax/setsites.php` — which **is** a real file. The front
controller rewrite generated by `\OC\Setup::updateHtaccess()` only forwards a
request to `index.php` when the requested path does **not** exist on disk:

```apache
RewriteCond %{REQUEST_FILENAME} !-f
RewriteRule . index.php [PT,E=PATH_INFO:$1]
```

The web server therefore executes the script directly, without the bootstrap
`index.php` would have performed, and the request dies with `Class "OC" not
found` → HTTP 500. The route was unreachable at its own declared url.

## Impact: latent, not a live bug

`OC.filePath()` unconditionally injects `/index.php/` for non-core app `.php`
files (`core/js/js.js`, the `file.substring(file.length - 3) === 'php' && !isCore`
branch), so the admin panel always requested the routed
`/index.php/apps/external/ajax/setsites.php` form — which works. Verified against
a pristine `owncloud/server:11.0.0-rc2`. The setting is not broken today.

The value here is that a route is reachable at the url it declares, and the bug
class cannot resurface if a caller is ever written the obvious way.

## What this changes

* The route url loses its `.php` suffix so that it no longer resolves to a file
  on disk. The `actionInclude()` target and the **route name** are unchanged, so
  `linkToRoute()` callers keep working.
* `js/admin.js` moves from `OC.filePath()` to `OC.generateUrl()`. Simply dropping
  the `.php` from the `OC.filePath()` call would not work: with a non-`.php` file
  name and a non-core app, `OC.filePath()` falls through to its
  `OC.appswebroots[app]` branch and yields a *static* url rather than a routed
  one.

No backwards-compatible `.php` alias is added — an alias would re-introduce
exactly the shadowed url this change removes, so it would be dead on arrival.

## Release note

This app needs its own release before an ownCloud bundle picks the change up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
