### PR TITLE
ci: add signed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: owncloud/reusable-workflows/.github/workflows/release.yml@main
+    with:
+      app-name: external
+    secrets:
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      SIGNING_CERT: ${{ secrets.SIGNING_CERT }}
+      SIGNING_CHAIN: ${{ secrets.SIGNING_CHAIN }}


### PR DESCRIPTION
Adds a tag-triggered release workflow so releases are built and signed in CI instead of by hand.

Pushing a `v*` tag now calls `owncloud/reusable-workflows/.github/workflows/release.yml`, which:

- checks the tag matches `<version>` in `appinfo/info.xml` and aborts if it does not,
- builds `ocsign` from a pinned commit and runs `make dist` with `CAN_SIGN=true` and `sign=ocsign ...`, so the existing `ifdef CAN_SIGN` block signs with the G2 material from the repository secrets,
- asserts each tarball contains an `appinfo/signature.json` (schema v2) whose leaf certificate CN equals the app id — an unsigned build fails rather than publishing quietly,
- creates the GitHub Release with `build/dist/external.tar.gz` attached.

No `Makefile` change is needed. `sign` is a plain `=` assignment, so the workflow overrides it on the make command line, and the tarball path already matches the workflow's default `artifact-glob` of `build/**/*.tar.gz`.

`SIGNING_KEY`, `SIGNING_CERT` and `SIGNING_CHAIN` are set as repository secrets. `dist.yml` is unaffected — it triggers on branch pushes and pull requests, not tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)