### PR TITLE
chore: bump version to 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-07-28
+
 ### Changed
 
 - Rewire the setsites ajax route to an extension-free url so it is reachable at its own declared url - [#32](https://github.com/owncloud/external/pull/32)
@@ -30,7 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Set max version to 10
 
-[Unreleased]: https://github.com/owncloud/external/compare/v1.5.1..master
+[Unreleased]: https://github.com/owncloud/external/compare/v1.5.2..master
+[1.5.2]: https://github.com/owncloud/external/compare/v1.5.1..v1.5.2
 [1.5.1]: https://github.com/owncloud/external/compare/v1.5.0..v1.5.1
 [1.5.0]: https://github.com/owncloud/external/compare/v1.4.0..v1.5.0
 [1.4.0]: https://github.com/owncloud/external/compare/v1.3.1...v1.4.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,5 +20,5 @@
 	<dependencies>
 		<owncloud min-version="10.15" max-version="11" />
 	</dependencies>
-	<version>1.5.1</version>
+	<version>1.5.2</version>
 </info>


### PR DESCRIPTION
Prepares the 1.5.2 release.

- `CHANGELOG.md`: promotes the unreleased entry for the extension-free ajax route fix ([#32](https://github.com/owncloud/external/pull/32)) to `## [1.5.2]`, and adds the compare links.
- `appinfo/info.xml`: `1.5.1` → `1.5.2`.

The version bump has to land before the tag: the release workflow added in #33 compares the tag against `<version>` in `appinfo/info.xml` and fails the release if they disagree.

Once merged, `v1.5.2` will be the first ownCloud Classic app release built and code-signed entirely in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)